### PR TITLE
Add signed_url method to AWS::S3::File and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Makefile
 MYMETA.yml
 MYMETA.json
+Makefile.old

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,8 @@
 Changes
+MANIFEST
+META.yml
+Makefile.PL
+README.markdown
 inc/Module/Install.pm
 inc/Module/Install/Base.pm
 inc/Module/Install/Can.pm
@@ -13,7 +17,6 @@ lib/AWS/S3/File.pm
 lib/AWS/S3/FileIterator.pm
 lib/AWS/S3/HTTPRequest.pm
 lib/AWS/S3/Owner.pm
-lib/AWS/S3/Request.pm
 lib/AWS/S3/Request/CreateBucket.pm
 lib/AWS/S3/Request/DeleteBucket.pm
 lib/AWS/S3/Request/DeleteFile.pm
@@ -29,9 +32,7 @@ lib/AWS/S3/Request/SetBucketAccessControl.pm
 lib/AWS/S3/Request/SetBucketPolicy.pm
 lib/AWS/S3/Request/SetFileContents.pm
 lib/AWS/S3/ResponseParser.pm
+lib/AWS/S3/Roles/BucketAction.pm
+lib/AWS/S3/Roles/Request.pm
 lib/AWS/S3/Signer.pm
-Makefile.PL
-MANIFEST			This list of files
-META.yml
-README.markdown
 t/010-basic/010-basic.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -37,3 +37,4 @@ lib/AWS/S3/Roles/Request.pm
 lib/AWS/S3/Signer.pm
 t/010-basic/010-basic.t
 t/020_endpoint.t
+t/040_file.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -36,3 +36,4 @@ lib/AWS/S3/Roles/BucketAction.pm
 lib/AWS/S3/Roles/Request.pm
 lib/AWS/S3/Signer.pm
 t/010-basic/010-basic.t
+t/020_endpoint.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ requires 'MIME::Base64';
 requires 'URI::Escape';
 requires 'Digest::HMAC_SHA1';
 requires 'Iterator::Paged';
+requires 'Test::Deep';
 
 resources(
   'repository'  => 'https://github.com/jdrago999/AWS-S3'

--- a/README.markdown
+++ b/README.markdown
@@ -6,30 +6,25 @@ AWS::S3 - Lightweight interface to Amazon S3 (Simple Storage Service)
 
     use AWS::S3;
     
-
     my $s3 = AWS::S3->new(
       access_key_id     => 'E654SAKIASDD64ERAF0O',
       secret_access_key => 'LgTZ25nCD+9LiCV6ujofudY1D6e2vfK0R4GLsI4H',
     );
     
-
     # Add a bucket:
     my $bucket = $s3->add_bucket(
       name    => 'foo-bucket',
     );
     
-
     # Set the acl:
     $bucket->acl( 'private' );
     
-
     # Add a file:
     my $new_file = $bucket->add_file(
       key       => 'foo/bar.txt',
       contents  => \'This is the contents of the file',
     );
     
-
     # You can also set the contents with a coderef:
     # Coderef should eturn a reference, not the actual string of content:
     $new_file = $bucket->add_file(
@@ -37,28 +32,22 @@ AWS::S3 - Lightweight interface to Amazon S3 (Simple Storage Service)
       contents  => sub { return \"This is the contents" }
     );
     
-
     # Get the file:
     my $same_file = $bucket->file( 'foo/bar.txt' );
     
-
     # Get the contents:
     my $scalar_ref = $same_file->contents;
     print $$scalar_ref;
     
-
     # Update the contents with a scalar ref:
     $same_file->contents( \"New file contents" );
     
-
     # Update the contents with a code ref:
     $same_file->contents( sub { return \"New file contents" } );
     
-
     # Delete the file:
     $same_file->delete();
     
-
     # Iterate through lots of files:
     my $iterator = $bucket->files(
       page_size   => 100,
@@ -76,19 +65,16 @@ AWS::S3 - Lightweight interface to Amazon S3 (Simple Storage Service)
       }# end foreach()
     }# end while()
     
-
     # You can't delete a bucket until it's empty.
     # Empty a bucket like this:
     while( my @files = $iterator->next_page )
     {
       map { $_->delete } @files;
       
-
       # Return to page 1:
       $iterator->page_number( 1 );
     }# end while()
     
-
     # Now you can delete the bucket:
     $bucket->delete();
 
@@ -96,25 +82,25 @@ AWS::S3 - Lightweight interface to Amazon S3 (Simple Storage Service)
 
 AWS::S3 attempts to provide an alternate interface to the Amazon S3 Simple Storage Service.
 
-__NOTE:__ Until AWS::S3 gets to version 1.000 it will not implement the full S3 interface.
+**NOTE:** Until AWS::S3 gets to version 1.000 it will not implement the full S3 interface.
 
-__Disclaimer:__ Several portions of AWS::S3 have been adopted from [Net::Amazon::S3](http://search.cpan.org/perldoc?Net::Amazon::S3).
+**Disclaimer:** Several portions of AWS::S3 have been adopted from [Net::Amazon::S3](https://metacpan.org/pod/Net::Amazon::S3).
 
-__NOTE:__ AWS::S3 is NOT a drop-in replacement for [Net::Amazon::S3](http://search.cpan.org/perldoc?Net::Amazon::S3).
+**NOTE:** AWS::S3 is NOT a drop-in replacement for [Net::Amazon::S3](https://metacpan.org/pod/Net::Amazon::S3).
 
-__TODO:__ CloudFront integration.
+**TODO:** CloudFront integration.
 
 # CONSTRUCTOR
 
 Call `new()` with the following parameters.
 
-## access_key_id
+## access\_key\_id
 
 Required.  String.
 
 Provided by Amazon, this is your access key id.
 
-## secret_access_key
+## secret\_access\_key
 
 Required.  String.
 
@@ -126,19 +112,25 @@ Optional.  Boolean.
 
 Default is `0`
 
+## endpoint
+
+Optional.  String.
+
+Default is `s3.amazonaws.com`
+
 ## ua
 
-Optional.  Should be an instance of [LWP::UserAgent](http://search.cpan.org/perldoc?LWP::UserAgent) or a subclass of it.
+Optional.  Should be an instance of [LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) or a subclass of it.
 
-Defaults to creating a new instance of [LWP::UserAgent::Determined](http://search.cpan.org/perldoc?LWP::UserAgent::Determined)
+Defaults to creating a new instance of [LWP::UserAgent::Determined](https://metacpan.org/pod/LWP::UserAgent::Determined)
 
 # PUBLIC PROPERTIES
 
-## access_key_id
+## access\_key\_id
 
 String.  Read-only
 
-## secret_access_key
+## secret\_access\_key
 
 String.  Read-only.
 
@@ -146,51 +138,55 @@ String.  Read-only.
 
 Boolean.  Read-only.
 
+## endpoint
+
+String.  Read-only.
+
 ## ua
 
-[LWP::UserAgent](http://search.cpan.org/perldoc?LWP::UserAgent) object.  Read-only.
+[LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) object.  Read-only.
 
 ## owner
 
-[AWS::S3::Owner](http://search.cpan.org/perldoc?AWS::S3::Owner) object.  Read-only.
+[AWS::S3::Owner](https://metacpan.org/pod/AWS::S3::Owner) object.  Read-only.
 
 # PUBLIC METHODS
 
 ## buckets
 
-Returns an array of [AWS::S3::Bucket](http://search.cpan.org/perldoc?AWS::S3::Bucket) objects.
+Returns an array of [AWS::S3::Bucket](https://metacpan.org/pod/AWS::S3::Bucket) objects.
 
 ## bucket( $name )
 
-Returns the [AWS::S3::Bucket](http://search.cpan.org/perldoc?AWS::S3::Bucket) object matching `$name` if found.
+Returns the [AWS::S3::Bucket](https://metacpan.org/pod/AWS::S3::Bucket) object matching `$name` if found.
 
 Returns nothing otherwise.
 
-## add_bucket( name => $name )
+## add\_bucket( name => $name )
 
 Attempts to create a new bucket with the name provided.
 
-On success, returns the new [AWS::S3::Bucket](http://search.cpan.org/perldoc?AWS::S3::Bucket)
+On success, returns the new [AWS::S3::Bucket](https://metacpan.org/pod/AWS::S3::Bucket)
 
 On failure, dies with the error message.
 
-See [AWS::S3::Bucket](http://search.cpan.org/perldoc?AWS::S3::Bucket) for details on how to use buckets (and access their files).
+See [AWS::S3::Bucket](https://metacpan.org/pod/AWS::S3::Bucket) for details on how to use buckets (and access their files).
 
 # SEE ALSO
 
 [The Amazon S3 API Documentation](http://docs.amazonwebservices.com/AmazonS3/latest/API/)
 
-[AWS::S3::Bucket](http://search.cpan.org/perldoc?AWS::S3::Bucket)
+[AWS::S3::Bucket](https://metacpan.org/pod/AWS::S3::Bucket)
 
-[AWS::S3::File](http://search.cpan.org/perldoc?AWS::S3::File)
+[AWS::S3::File](https://metacpan.org/pod/AWS::S3::File)
 
-[AWS::S3::FileIterator](http://search.cpan.org/perldoc?AWS::S3::FileIterator)
+[AWS::S3::FileIterator](https://metacpan.org/pod/AWS::S3::FileIterator)
 
-[AWS::S3::Owner](http://search.cpan.org/perldoc?AWS::S3::Owner)
+[AWS::S3::Owner](https://metacpan.org/pod/AWS::S3::Owner)
 
 # AUTHOR
 
-John Drago <jdrago_999@yahoo.com>
+John Drago <jdrago\_999@yahoo.com>
 
 # LICENSE AND COPYRIGHT
 

--- a/lib/AWS/S3.pm
+++ b/lib/AWS/S3.pm
@@ -24,6 +24,13 @@ has 'secure' => (
     default => 0
 );
 
+has 'endpoint' => (
+    is      => 'ro',
+    isa     => 'Str',
+    lazy    => 1,
+    default => sub { 's3.amazonaws.com' },
+);
+
 has 'ua' => (
     is      => 'ro',
     isa     => 'LWP::UserAgent',
@@ -214,6 +221,12 @@ Optional.  Boolean.
 
 Default is C<0>
 
+=head2 endpoint
+
+Optional.  String.
+
+Default is C<s3.amazonaws.com>
+
 =head2 ua
 
 Optional.  Should be an instance of L<LWP::UserAgent> or a subclass of it.
@@ -233,6 +246,10 @@ String.  Read-only.
 =head2 secure
 
 Boolean.  Read-only.
+
+=head2 endpoint
+
+String.  Read-only.
 
 =head2 ua
 

--- a/lib/AWS/S3/File.pm
+++ b/lib/AWS/S3/File.pm
@@ -118,6 +118,7 @@ sub update {
     if ( @args_ok ) {
         $s->{$_} = $args{$_} for @args_ok;
         $s->_set_contents();
+        return 1;
     }
     return;
 }    # end update()

--- a/lib/AWS/S3/File.pm
+++ b/lib/AWS/S3/File.pm
@@ -159,6 +159,21 @@ sub _set_contents {
     }    # end if()
 }    # end _set_contents()
 
+sub signed_url {
+    my $s       = shift;
+    my $expires = shift || time + 3600;
+
+    my $type = "GetPreSignedUrl";
+    my $uri  = $s->bucket->s3->request(
+        $type,
+        bucket  => $s->bucket->name,
+        key     => $s->key,
+        expires => $expires,
+    )->request;
+
+    return $uri;
+}
+
 sub delete {
     my $s = shift;
 
@@ -216,6 +231,9 @@ AWS::S3::File - A single file in Amazon S3
     contents => \'New contents', # optional
     contenttype => 'text/plain'  # optional
   );
+
+  # Get signed URL for the file for public access
+  print $file->signed_url( $expiry_time );
   
   # Delete the file:
   $file->delete();
@@ -298,6 +316,11 @@ Deletes the file from Amazon S3.
 =head2 update()
 
 Update contents and/or contenttype of the file.
+
+=head2 signed_url( $expiry_time )
+
+Will return a signed URL for public access to the file. $expiry_time should be a
+Unix seconds since epoch, and will default to now + 1 hour is not passed
 
 =head1 SEE ALSO
 

--- a/lib/AWS/S3/HTTPRequest.pm
+++ b/lib/AWS/S3/HTTPRequest.pm
@@ -75,9 +75,10 @@ sub http_request {
     my $metadata = $s->metadata;
 
     my $protocol = $s->s3->secure ? 'https' : 'http';
-    my $uri = "$protocol://s3.amazonaws.com/$path";
+	my $endpoint = $s->s3->endpoint;
+    my $uri = "$protocol://$endpoint/$path";
     if ( $path =~ m{^([^/?]+)(.*)} && _is_dns_bucket( $1 ) ) {
-        $uri = "$protocol://$1.s3.amazonaws.com$2";
+        $uri = "$protocol://$1.$endpoint$2";
     }    # end if()
 
     my $signer = AWS::S3::Signer->new(

--- a/lib/AWS/S3/Request/CreateBucket.pm
+++ b/lib/AWS/S3/Request/CreateBucket.pm
@@ -2,6 +2,8 @@
 package AWS::S3::Request::CreateBucket;
 use Moose;
 
+use AWS::S3::Signer;
+
 with 'AWS::S3::Roles::Request';
 
 has 'bucket' => (
@@ -30,7 +32,7 @@ XML
         my $signer = AWS::S3::Signer->new(
             s3           => $s->s3,
             method       => 'PUT',
-            uri          => $s->protocol . '://' . $s->bucket . '.s3.amazonaws.com/',
+            uri          => $s->protocol . '://' . $s->bucket . '.' . $s->endpoint . '/',
             content_type => 'text/plain',
             content_md5  => '',
             content      => \$xml,
@@ -48,7 +50,7 @@ XML
         my $signer = AWS::S3::Signer->new(
             s3     => $s->s3,
             method => 'PUT',
-            uri    => $s->protocol . '://s3.amazonaws.com/' . $s->bucket,
+            uri    => $s->protocol . '://' . $s->endpoint . '/' . $s->bucket,
         );
         return $s->_send_request(
             $signer->method => $signer->uri => {

--- a/lib/AWS/S3/Request/GetPreSignedUrl.pm
+++ b/lib/AWS/S3/Request/GetPreSignedUrl.pm
@@ -1,0 +1,38 @@
+
+package AWS::S3::Request::GetPreSignedUrl;
+use Moose;
+
+use AWS::S3::Signer;
+
+with 'AWS::S3::Roles::Request';
+
+has 'bucket' => ( is => 'ro', isa => 'Str', required => 1 );
+has 'key' => ( is => 'ro', isa => 'Str', required => 1 );
+has 'expires' => ( is => 'ro', isa => 'Int', required => 1 );
+
+sub request {
+    my $s = shift;
+
+    my $uri = $s->_uri;
+
+    my $req = "GET\n\n\n"
+        . $s->expires . "\n/"
+        . $s->bucket . "/"
+        . $s->key;
+
+    my $signer = AWS::S3::Signer->new(
+        s3             => $s->s3,
+        method         => "GET",
+        uri            => $uri,
+        string_to_sign => $req,
+    );
+
+    my $signed_uri = $uri->as_string
+        . '?AWSAccessKeyId=' . $s->s3->access_key_id
+        . '&Expires=' . $s->expires
+        . '&Signature=' . $signer->signature;
+
+    return $signed_uri;
+}
+
+__PACKAGE__->meta->make_immutable;

--- a/lib/AWS/S3/Request/ListBucket.pm
+++ b/lib/AWS/S3/Request/ListBucket.pm
@@ -48,7 +48,7 @@ sub request {
     my $signer = AWS::S3::Signer->new(
         s3     => $s->s3,
         method => 'GET',
-        uri => $s->protocol . '://' . $s->bucket . '.s3.amazonaws.com/' . ( @params ? '?' . join( '&', @params ) : '' ),
+        uri => $s->protocol . '://' . $s->bucket . '.' . $s->endpoint . '/' . ( @params ? '?' . join( '&', @params ) : '' ),
     );
     $s->_send_request(
         $signer->method => $signer->uri => {

--- a/lib/AWS/S3/Request/SetBucketAccessControl.pm
+++ b/lib/AWS/S3/Request/SetBucketAccessControl.pm
@@ -33,7 +33,7 @@ sub request {
         my $signer = AWS::S3::Signer->new(
             s3      => $s->s3,
             method  => 'PUT',
-            uri     => $s->protocol . '://' . $s->bucket . '.s3.amazonaws.com/?acl',
+            uri     => $s->protocol . '://' . $s->bucket . '.' . $s->endpoint . '/?acl',
             headers => [ 'x-amz-acl' => $s->acl_short ]
         );
         return $s->_send_request(
@@ -48,7 +48,7 @@ sub request {
         my $signer = AWS::S3::Signer->new(
             s3             => $s->s3,
             method         => 'PUT',
-            uri            => $s->protocol . '://' . $s->bucket . '.s3.amazonaws.com/?acl',
+            uri            => $s->protocol . '://' . $s->bucket . '.' . $s->endpoint . '/?acl',
             content        => \$s->acl_xml,
             'content-type' => 'text/xml',
         );

--- a/lib/AWS/S3/Request/SetFileContents.pm
+++ b/lib/AWS/S3/Request/SetFileContents.pm
@@ -45,7 +45,7 @@ sub request {
     my $signer = AWS::S3::Signer->new(
         s3           => $s->s3,
         method       => 'PUT',
-        uri          => $s->protocol . '://' . $s->bucket . '.s3.amazonaws.com/' . $s->file->key,
+        uri          => $s->protocol . '://' . $s->bucket . '.' . $s->endpoint . '/' . $s->file->key,
         content_type => $s->content_type,
         content      => $contents,
         headers      => [ 'x-amz-storage-class', $s->file->storage_class ],

--- a/lib/AWS/S3/Roles/Request.pm
+++ b/lib/AWS/S3/Roles/Request.pm
@@ -25,6 +25,15 @@ has 'protocol' => (
     }
 );
 
+has 'endpoint' => (
+    is      => 'ro',
+    isa     => 'Str',
+    lazy    => 1,
+    default => sub {
+        shift->s3->endpoint;
+    }
+);
+
 # XXX should be required=>1; https://rt.cpan.org/Ticket/Display.html?id=77863
 has "_action" => (
     isa       => 'Str',
@@ -46,7 +55,8 @@ has '_uri' => (
         my $uri = URI->new(
             $self->protocol . '://'
             . ( $m->has_attribute('bucket') ? $self->bucket . '.' : '' )
-            . 's3.amazonaws.com/'
+            . $self->endpoint
+            . '/'
         );
 
         $uri->path( $self->key )

--- a/t/010-basic/010-basic.t
+++ b/t/010-basic/010-basic.t
@@ -33,7 +33,7 @@ isa_ok $owner, 'AWS::S3::Owner';
 ok $owner->id, 'owner.id';
 ok $owner->display_name, 'owner.display_name';
 
-my $bucket_name = "aws-s3-test-" . int(rand() * 1_000_000) . '-' . time() . "-foo";
+my $bucket_name = $ENV{AWS_TEST_BUCKET} || "aws-s3-test-" . int(rand() * 1_000_000) . '-' . time() . "-foo";
 ok my $bucket = $s3->add_bucket( name => $bucket_name, location => 'us-west-1' ), "created bucket '$bucket_name'";
 
 #exit;

--- a/t/020_endpoint.t
+++ b/t/020_endpoint.t
@@ -1,0 +1,30 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+use FindBin qw/ $Bin /;
+
+use Carp 'confess';
+$SIG{__DIE__} = \&confess;
+
+use_ok('AWS::S3');
+
+my $s3 = AWS::S3->new(
+  access_key_id     => $ENV{AWS_ACCESS_KEY_ID}     // 'foo',
+  secret_access_key => $ENV{AWS_SECRET_ACCESS_KEY} // 'bar',
+  endpoint          => 'bad.hostname',
+);
+
+my $bucket_name = "aws-s3-test-" . int(rand() * 1_000_000) . '-' . time() . "-foo";
+
+eval {
+    my $bucket = $s3->add_bucket( name => $bucket_name, location => 'us-west-1' ),
+};
+
+like(
+    $@,
+    qr/Can't connect to aws-s3-test-.*?bad\.hostname/,
+    'endpoint was used'
+);

--- a/t/030_signer.t
+++ b/t/030_signer.t
@@ -1,0 +1,36 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+use FindBin qw/ $Bin /;
+
+use Carp 'confess';
+$SIG{__DIE__} = \&confess;
+
+use_ok('AWS::S3');
+
+my $s3 = AWS::S3->new(
+  access_key_id     => $ENV{AWS_ACCESS_KEY_ID}     // 'foo',
+  secret_access_key => $ENV{AWS_SECRET_ACCESS_KEY} // 'bar',
+  endpoint          => $ENV{AWS_ENDPOINT}          // 'baz',
+);
+
+use_ok('AWS::S3::Signer');
+
+isa_ok(
+	my $signer = AWS::S3::Signer->new(
+		method  => 'HEAD',
+		s3      => $s3,
+		uri     => "http://baz/boz",
+		content => \'hello world',
+	),
+	'AWS::S3::Signer'
+);
+
+is( $signer->content_type,'text/plain','content_type' );
+is( $signer->method,'HEAD','method' );
+is( ${ $signer->content },'hello world','content' );
+
+like( $signer->auth_header,qr/AWS foo:.{28}/,'auth_header' );

--- a/t/030_signer.t
+++ b/t/030_signer.t
@@ -3,7 +3,8 @@
 use strict;
 use warnings;
 
-use Test::More 'no_plan';
+use Test::More;
+use Test::Deep;
 use FindBin qw/ $Bin /;
 
 use Carp 'confess';
@@ -11,26 +12,67 @@ $SIG{__DIE__} = \&confess;
 
 use_ok('AWS::S3');
 
+note( "construction" );
 my $s3 = AWS::S3->new(
-  access_key_id     => $ENV{AWS_ACCESS_KEY_ID}     // 'foo',
-  secret_access_key => $ENV{AWS_SECRET_ACCESS_KEY} // 'bar',
-  endpoint          => $ENV{AWS_ENDPOINT}          // 'baz',
+    access_key_id     => $ENV{AWS_ACCESS_KEY_ID}     // 'foo',
+    secret_access_key => $ENV{AWS_SECRET_ACCESS_KEY} // 'bar',
+    endpoint          => $ENV{AWS_ENDPOINT}          // 's3.baz.com',
 );
 
 use_ok('AWS::S3::Signer');
 
 isa_ok(
-	my $signer = AWS::S3::Signer->new(
-		method  => 'HEAD',
-		s3      => $s3,
-		uri     => "http://baz/boz",
-		content => \'hello world',
-	),
-	'AWS::S3::Signer'
+    my $signer = AWS::S3::Signer->new(
+        method  => 'HEAD',
+        s3      => $s3,
+        uri     => "http://maibucket.s3.baz.com/boz",
+        content => \'hello world',
+    ),
+    'AWS::S3::Signer'
 );
 
-is( $signer->content_type,'text/plain','content_type' );
-is( $signer->method,'HEAD','method' );
-is( ${ $signer->content },'hello world','content' );
+can_ok(
+    $signer,
+    qw/
+        s3
+        method
+        bucket_name
+        uri
+        headers
+        date
+        string_to_sign
+        canonicalized_amz_headers
+        canonicalized_resource
+        content_type
+        content_md5
+        content
+        content_length
+        signature
+    /,
+);
 
+
+note( "attributes" );
+isa_ok( $signer->s3,'AWS::S3' );
+is( $signer->method,'HEAD','method' );
+is( $signer->bucket_name,'maibucket','bucket_name' );
+isa_ok( $signer->uri,'URI' );
+cmp_deeply( $signer->headers,[],'headers' );
+like( $signer->date,qr/\w+, +\d{1,2} \w+ \d{4} \d{2}:\d{2}:\d{2}/,'date' );
+is(
+    $signer->string_to_sign,
+    "HEAD\nXrY7u+Ae7tCTyyK7j1rNww==\ntext/plain\n".$signer->date."\n/maibucket/boz",
+    'string_to_sign'
+);
+is( $signer->canonicalized_amz_headers,'','canonicalized_amz_headers' );
+is( $signer->canonicalized_resource,'/maibucket/boz','canonicalized_resource' );
+is( $signer->content_type,'text/plain','content_type' );
+is( $signer->content_md5,'XrY7u+Ae7tCTyyK7j1rNww==','content_md5' );
+is( ${ $signer->content },'hello world','content' );
+is( $signer->content_length,11,'content_length' );
+like( $signer->signature,qr/^.{28}$/,'signature' );
+
+note( "methods" );
 like( $signer->auth_header,qr/AWS foo:.{28}/,'auth_header' );
+
+done_testing();

--- a/t/040_file.t
+++ b/t/040_file.t
@@ -1,0 +1,87 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Deep;
+use FindBin qw/ $Bin $Script /;
+
+use Carp 'confess';
+$SIG{__DIE__} = \&confess;
+
+use_ok('AWS::S3');
+
+note( "construction" );
+my $s3 = AWS::S3->new(
+    access_key_id     => $ENV{AWS_ACCESS_KEY_ID}     // 'foo',
+    secret_access_key => $ENV{AWS_SECRET_ACCESS_KEY} // 'bar',
+    endpoint          => $ENV{AWS_ENDPOINT}          // 's3.baz.com',
+);
+
+use_ok('AWS::S3::File');
+use_ok('AWS::S3::Bucket');
+use_ok('AWS::S3::Request::SetFileContents');
+
+monkey_patch_module();
+
+isa_ok(
+    my $file = AWS::S3::File->new(
+        key          => "$Script",
+        contents     => sub { 'test file contents' },
+        is_encrypted => 0,
+        bucket       => AWS::S3::Bucket->new(
+            s3   => $s3,
+            name => $ENV{AWS_TEST_BUCKET} // 'maibucket',
+        ),
+    ),
+    'AWS::S3::File'
+);
+
+can_ok(
+    $file,
+    qw/
+        key
+        bucket
+        size
+        etag
+        owner
+        storage_class
+        lastmodified
+        contenttype
+        is_encrypted
+        contents
+    /,
+);
+
+note( "attributes" );
+isa_ok( $file->bucket,'AWS::S3::Bucket','bucket' );
+is( $file->key,$Script,'key' );
+is( $file->size,'18','size' );
+isa_ok( $file->etag,'main','etag' );
+is( $file->owner,undef,'owner' );
+is( $file->storage_class,'STANDARD','storage_class' );
+is( $file->lastmodified,undef,'lastmodified' );
+is( $file->contenttype,'binary/octet-stream','contenttype' );
+is( $file->is_encrypted,0,'is_encrypted' );
+isa_ok( $file->contents,'SCALAR','contents' );
+
+note( "methods" );
+ok( !$file->update,'update without args' );
+ok( $file->update( contents => \'new contents' ),'update with args' );
+
+done_testing();
+
+sub monkey_patch_module {
+    # monkey patching for true(r) unit tests
+    no warnings 'redefine';
+    no warnings 'once';
+
+    sub response { return shift; }
+    sub header { return shift; }
+    sub friendly_error { return; }
+
+    *AWS::S3::Request::SetFileContents::request = sub {
+        return bless( {},'main' );
+    };
+}

--- a/t/040_file.t
+++ b/t/040_file.t
@@ -27,7 +27,7 @@ monkey_patch_module();
 
 isa_ok(
     my $file = AWS::S3::File->new(
-        key          => "$Script",
+        key          => $ENV{AWS_TEST_KEY} // "$Script",
         contents     => sub { 'test file contents' },
         is_encrypted => 0,
         bucket       => AWS::S3::Bucket->new(
@@ -69,6 +69,12 @@ isa_ok( $file->contents,'SCALAR','contents' );
 note( "methods" );
 ok( !$file->update,'update without args' );
 ok( $file->update( contents => \'new contents' ),'update with args' );
+
+is(
+    $file->signed_url( 1406712744 ),
+    'http://maibucket.s3.baz.com/040_file.t?AWSAccessKeyId=foo&Expires=1406712744&Signature=gqOO//FsAuSTvgEwBYPp0tX1rOU=',
+    'signed_url'
+);
 
 done_testing();
 


### PR DESCRIPTION
N.B. this builds upon changes from PR #6 and #8.

This returns the signed URL for public access to a file, the expiry time can be passed into the method or will default to now + 1 hour in the future. Add perldoc and tests for these changes, update MANIFEST.

Although the URL is built on the client side this has been implemented using the same structure as other requests with a GetPreSignedUrl class that uses the AWS::S3:Roles::Request role to get at the _uri attribute. We don't actually go out to AWS for this method, but who knows what the future holds?
